### PR TITLE
feat(types): Export types

### DIFF
--- a/src/fakeHr.ts
+++ b/src/fakeHr.ts
@@ -1,2 +1,8 @@
 export * as competencies from './competencies';
 export * as education from './education';
+export type {
+  CountryCode,
+  EducationInstitution,
+  EducationLevel,
+  EducationQualification,
+} from './types';


### PR DESCRIPTION
This is helpful for annotating helper functions etc. in consumer code. We're already using these types in our public interface but they're not named.

Apparently you can't use `export type *` so this just names our existing types. This might be safer if we add some internal types but it'll make it easy to forget new types in the future. I'm happy to switch to `export *` if that's better.